### PR TITLE
feat: 添加监控订单状态控制器：MonitorController

### DIFF
--- a/src/main/java/com/uniview/project0719/controller/MonitorController.java
+++ b/src/main/java/com/uniview/project0719/controller/MonitorController.java
@@ -1,0 +1,40 @@
+package com.uniview.project0719.controller;
+
+import com.uniview.project0719.service.UserOrderService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Kurt LEE
+ * @created 2024/07/26 - 下午3:53
+ * 监控组件控制器
+ */
+@RestController("/monitor")
+@Tag(name = "MonitorController", description = "监控组件控制器")
+public class MonitorController {
+    @Autowired
+    private UserOrderService userOrderService;
+
+    /**
+     * 获取所有订单数量
+     * @return
+     */
+    @GetMapping("/getAllOrderCount")
+    public Long getTotalOrderCount() {
+        return userOrderService.getTotalOrderCount();
+    }
+
+    /**
+     * 根据订单状态获取订单数量
+     * 备注：1待支付、2待收货、3待评价、4售后处理中、5已退款、7已取消（超时自动取消）。参见MySQL t_user_order表status字段
+     * @param status
+     * @return
+     */
+    @GetMapping("/status/{status}")
+    public Long getOrderCountByStatus(@PathVariable Integer status) {
+        return userOrderService.getOrderCountByStatus(status);
+    }
+}

--- a/src/main/java/com/uniview/project0719/repository/UserOrderRepository.java
+++ b/src/main/java/com/uniview/project0719/repository/UserOrderRepository.java
@@ -3,7 +3,18 @@ package com.uniview.project0719.repository;
 import com.uniview.project0719.entity.UserOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
 
-public interface UserOrderRepository extends JpaRepository<UserOrder,String>, JpaSpecificationExecutor<UserOrder> {
+public interface UserOrderRepository extends JpaRepository<UserOrder, String>, JpaSpecificationExecutor<UserOrder> {
     UserOrder findUserOrderByOrderId(String orderId);
+
+    //    Created by @Kurt LEE. Last Modified on 2024/7/26, 下午3:42.
+    // 检索所有订单数量
+    @Query("SELECT COUNT(o) FROM UserOrder o")
+    Long countAllOrders();
+
+    // 根据订单状态查找订单数量
+    @Query("SELECT COUNT(o) FROM UserOrder o WHERE o.status = :status")
+    Long countOrdersByStatus(Integer status);
 }

--- a/src/main/java/com/uniview/project0719/service/UserOrderService.java
+++ b/src/main/java/com/uniview/project0719/service/UserOrderService.java
@@ -7,6 +7,7 @@ import com.uniview.project0719.utils.ParamData;
 import com.uniview.project0719.utils.ResponseData;
 
 import java.text.ParseException;
+import java.util.Map;
 
 public interface UserOrderService {
     /**
@@ -29,4 +30,16 @@ public interface UserOrderService {
      * @return
      */
     ResponseData<?> getUserOrderDetail(ParamData<OrderItemDTO> paramData);
+
+    /**
+     * Created by @Kurt LEE. Last Modified on 2024/7/26, 下午3:45.
+     * 获取所有订单数量
+     */
+    Long getTotalOrderCount();
+
+    /**
+     * Created by @Kurt LEE. Last Modified on 2024/7/26, 下午3:45.
+     * @return
+     */
+    Long getOrderCountByStatus(Integer status);
 }

--- a/src/main/java/com/uniview/project0719/service/impl/UserOrderServiceImpl.java
+++ b/src/main/java/com/uniview/project0719/service/impl/UserOrderServiceImpl.java
@@ -101,4 +101,24 @@ public class UserOrderServiceImpl implements UserOrderService {
         map.put("total", itemPage.getTotalPages());
         return new ResponseData<>().success(map);
     }
+
+    /**
+     * Created by @Kurt LEE. Last Modified on 2024/7/26, 下午3:45.
+     *
+     */
+    @Override
+    public Long getTotalOrderCount() {
+        return userOrderRepository.countAllOrders();
+    }
+
+    /**
+     * Created by @Kurt LEE. Last Modified on 2024/7/26, 下午3:48.
+     *
+     * @return
+     */
+    @Override
+    public Long getOrderCountByStatus(Integer status) {
+        return userOrderRepository.countOrdersByStatus(status);
+    }
+
 }


### PR DESCRIPTION
添加监控订单状态控制器：MonitorController
实现：1. 获取当前所有订单数量
     2. 根据订单状态获取当前状态下订单数量
     3. MonitorController 独立，调用 UserOrderRepository & UserOrderService